### PR TITLE
Zmenšení velikosti písma

### DIFF
--- a/shared.tex
+++ b/shared.tex
@@ -3,8 +3,8 @@
 % Git hash repozitáře v době kopírování: 35133a18ec74b314184f538e33c7f92054123d09
 
 \documentclass[
-    % Velikost základního písma je 12 bodů
-    12pt,
+    % Velikost základního písma je 10 bodů
+    10pt,
     % Formát papíru je A4
     a4paper,
     % Oboustranný tisk


### PR DESCRIPTION
Pro tisk A4 je velikost písma 10 dostačující. Pro čtení na monitoru by bylo vhodné si odpovídající dokumenty přegenerovat lokálně.