### PR TITLE
Změna sázení popisků

### DIFF
--- a/shared.tex
+++ b/shared.tex
@@ -128,7 +128,7 @@
 \usepackage{subfig}
 % Nastavení popisů obrázků, výpisů a tabulek
 \usepackage{caption}
-\captionsetup{justification=centering}
+\captionsetup{justification=raggedright,format=hang}
 % Grafy a vektorové obrázky
 \usepackage{tikz}
 \usetikzlibrary{shapes,arrows}


### PR DESCRIPTION
Místo zarovnání nastřed se popisky obrázků a tabulek sází zarovnané vlevo, s odsazením druhého a dalšího řádku. Zarovnání uprostřed je zachováno pro jednořádkové popisky. Delší popisky jdou takto lépe přečíst.